### PR TITLE
types: allow for promises of promises/promise stars

### DIFF
--- a/examples/stream.txt
+++ b/examples/stream.txt
@@ -1,0 +1,46 @@
+record StreamElement begin
+  next: Promise(StreamElementOption);
+  requestNext: Promise*(Bool);
+  value: Int
+end
+
+union StreamElementOption begin
+  Next[StreamElement];
+  End[]
+end
+
+func streamCounter(state : Int): StreamElement begin
+  println("Stream!");
+  promise getNext, setNext : StreamElementOption in
+  promise nextRequested, requestNext : Bool in
+  async (
+    if ?nextRequested then
+      setNext <- Next[streamCounter(state + 1)]
+    else
+      setNext <- End[]
+    end
+  );
+  StreamElement { next = getNext, requestNext = requestNext, value = state }
+end
+
+func consume(stream: StreamElement, max: Int): Unit begin
+  println("Consume!");
+  match stream begin
+    { next = next, requestNext = requestNext, value = value } ->
+      println(intToString(value));
+      if value >= max then
+        requestNext <- false
+      else
+        println("More!");
+        requestNext <- true
+      end;
+      match ?next begin
+        Next[cont] -> consume(cont, max)
+        End[] -> ()
+      end
+  end
+end
+
+func main(): Unit begin
+  consume(streamCounter(1), 3)
+end

--- a/src/lang.ml
+++ b/src/lang.ml
@@ -3,8 +3,8 @@ type primitive_ty =
 
 type ty = [
   | primitive_ty
-  | `Promise of primitive_ty
-  | `PromiseStar of primitive_ty
+  | `Promise of ty
+  | `PromiseStar of ty
   | `Function of ty list * ty
   | `Infer of ty option ref ]
 
@@ -14,8 +14,8 @@ let rec string_of_ty = function
   | `String -> "String"
   | `Unit -> "Unit"
   | `Custom name -> name
-  | `Promise ty -> "Promise(" ^ string_of_ty (ty :> ty) ^ ")"
-  | `PromiseStar ty -> "Promise*(" ^ string_of_ty (ty :> ty) ^ ")"
+  | `Promise ty -> "Promise(" ^ string_of_ty ty ^ ")"
+  | `PromiseStar ty -> "Promise*(" ^ string_of_ty ty ^ ")"
   | `Function (args, result) ->
      "(" ^ String.concat ", " (List.map string_of_ty args) ^ ") -> " ^ string_of_ty result
   | `Infer { contents = Some ty } -> string_of_ty ty
@@ -118,7 +118,7 @@ and expr =
   | ConstructUnion of { unionCtor: string; unionArgs: expr list }
   | ConstructRecord of { recordCtor: string; recordArgs: (string * expr) list }
   | RecordAccess of { record: expr; field: string }
-  | Promise of { read: string; write: string; ty: primitive_ty; promiseBody: expr }
+  | Promise of { read: string; write: string; ty: ty; promiseBody: expr }
   | Write of { promiseStar: expr; newValue: expr; unsafe: bool }
   | Read of { promise: expr }
   | Async of { application: expr }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -114,9 +114,9 @@ type_expr:
 *)
   | ty = primitive_type
      { ty :> Lang.ty }
-  | TYPE_PROMISE MUL LEFT_PAREN; t = primitive_type; RIGHT_PAREN
+  | TYPE_PROMISE MUL LEFT_PAREN; t = type_expr; RIGHT_PAREN
      { `PromiseStar t }
-  | TYPE_PROMISE LEFT_PAREN; t = primitive_type; RIGHT_PAREN
+  | TYPE_PROMISE LEFT_PAREN; t = type_expr; RIGHT_PAREN
      { `Promise t }
 ;
 


### PR DESCRIPTION
This removes the split between primitive types & normal types. This
split was previously used to make it impossible to create a type like
Promise(Promise*(Int)). However, this _is_ a safe construct:

1. Promise(Promise*(Int)) cannot duplicate a Promise*(Int):

   Because Promise(Promise*(Int)) is linear, we cannot duplicate it.
   We can only use it by transferring ownership of the value (via call
   or move) OR with the ? operator. The ? operator uses the promise and
   gives us a new linear value, Promise*(Int) that also cannot be
   duplicated.

2. Promise(Promise*(Int)) cannot drop a Promise*(Int):

   Similar logic applies: We cannot drop the promise, as it is linear.
   Once we read the promise, we are left with a linear variable of type
   Promise*(Int) that also cannot be dropped.

The only possible error that can exist here is in the interaction of
unsafeWrite (<~) and Promise*(Promise*(Int)):

    promise getP, setP : Promise*(Int) in
    promise getA, setA : Int in
    promise getB, setB : Int in
    setP <- setA;
    getP <~ setB -- Now setA is lost -> omitted write!
    -- getP is now also used. So not only is setA lost, but setB is
    -- also lost! This leaves us with _2_ omitted writes!

Given that unsafeWrite is _unsafe_ this is probably a reasonable thing
to allow. However, I am hesitant to enable this because it does break the
soundness of unsafeWrite as described in the paper.